### PR TITLE
Bump the docker-base-images group with 1 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # java-builder: Stage to build a custom JRE (with jlink)
-FROM eclipse-temurin:11@sha256:1ebad7e867415ed9f523dad6c4f38de9f7bd24e2b2a60812c5868c0ffde11924 as java-builder
+FROM eclipse-temurin:11@sha256:1f62aaa9b6947e96189b4dbd14a7fc2a768914df3aefc9b0a1f7ec8a4dce8d6b as java-builder
 
 # create a custom, minimized JRE via jlink
 RUN jlink --add-modules \


### PR DESCRIPTION
Bumps the docker-base-images group with 1 update: eclipse-temurin.


---
updated-dependencies:
- dependency-name: eclipse-temurin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: docker-base-images ...

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation


<!-- What notable changes does this PR make? -->
## Changes


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

